### PR TITLE
Fix invalid redirect

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -1,4 +1,4 @@
-var baseURL = 'http://gensat-thpani.rhcloud.com/';
+var baseURL = 'https://gensat-thpani.rhcloud.com/';
 angular
   .module('kripkeBuilder', [])
   .directive('kripkeNav', function() {


### PR DESCRIPTION
[http://gensat-thpani.rhcloud.com](http://gensat-thpani.rhcloud.com) answers with a `307` to it's HTTPS equivalent.

This results in the following error message:
`Failed to load http://gensat-thpani.rhcloud.com/: Response for preflight is invalid (redirect)`

Therefore I changed the URL to the redirection target (HTTPS equivalent).

Unfortunately the e2e tests are broken right now, but the test result is the same in my feature branch as in the master.

It would be nice if you could update the version deployed at http://forsyte.at/kripke/
Thanks!